### PR TITLE
Submitting Evaluation of FreeCodeCamp

### DIFF
--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -1,0 +1,154 @@
+# Project Name:  <!-- replace with the project name -->   
+
+
+
+**Evaluating Person or Team**:
+<!-- list your first name and github user-name-->
+
+---
+
+## Project Data
+
+1. Project description: <br>
+<!--
+What is the purpose of this project? What does the code do? What type of users
+does it have?
+-->
+
+1. Project website/homepage:
+
+1. Project repository:
+
+
+
+## License
+
+1. What is the project's license? <br>
+<!--
+In most repositories there will be a file named LICENSE or something similar in
+the root level of the repository. This is the one to examine. There may be
+different licenses on specific files, but the project will have a main license.
+-->
+
+
+
+## Code Base
+
+
+1. What is the primary programming language in the project?
+
+1. What is the development environment? <br>
+	<!--
+	For example, is it Gnu C++ on Linux?
+	Is it a Windows 10 application? Does one need to develop in a virtual machine?
+	-->
+
+1. Are there instructions for how to download, build, and install? How easy is it
+to find them? Do they seem easy (relatively speaking) to follow? <br>
+
+1. Does the project depend on external additional software modules such as
+database,  graphics, web development, or other libraries? If so, are there clear instructions on how to install those? <br>
+
+1. Is the code easy to understand? Browse some source code files and make
+a judgment based on your random sample. <br>
+
+1. Is this a big project? If you can, find out about how many lines of code
+are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
+
+1. Does the repository have tests? If so, are the code contributors expected to write tests for newly added code? <br>
+
+
+
+## Code and Design Documentation
+1. Is there clear documentation in the code itself? <br>
+
+1. Is there documentation about the design?  <br>
+
+
+## Activity Level
+
+
+1. How many commits have been made in the past week? <br>
+
+1. When was the most recent commit? <br>
+
+1. How many issues are currently open? <br>
+
+1. How long do issues stay open? <br>
+	<!--
+	Take the five closed issues (they can be most recently closed or a sample distributed over time) and look at when each was first reported.
+	Compute the number of days that each was open and take the average.
+	-->
+
+1. Read the conversations from some open and some closed issues. Is there active discussion on the issues? <br>
+
+1. Are issues tagged as easy, hard, for beginners, etc.? <br>
+
+1. How many issues were closed in the past six months? <br>
+
+1. Is there information about how many people are maintaining the project? <br>
+
+1. How many contributors has the project had in the past six months? <br>
+
+1. How many open pull requests are there? <br>
+
+1. Do pull requests remain un-answered for a long time? <br>
+	<!--
+	Look at the closed pull requests to see how long they stayed open.
+	Take the five closed pull requests  (they can be most recently closed or a sample distributed over time) and look at when each was first created.
+	Compute the number of days that each was open and take the average.
+	-->
+
+1. Read the conversations from some open and some closed pull requests.  Is there active discussion on the pull requests? <br>
+
+1. How many pull requests were opened within the past six months? <br>
+
+1. When was the last  pull request  merged? <br>
+
+## Welcomeness and Community
+
+1. Is there a CONTRIBUTING document? If so, how easy to read and understand is it?
+Look through it and see if it is clear and thorough. <br>
+
+1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
+violate it? <br>
+
+1. Do the maintainers respond helpfully to questions in issues?
+Are responses generally constructive? Read the issue conversations. <br>
+
+1. Are people friendly in the issues, discussion forum, and chat? <br>
+
+1. Do maintainers thank people for their contributions? <br>
+
+
+## Development Environment Installation
+
+Install the development environment for the project on your system.
+Describe the process that you needed to follow:
+
+1. how involved was the process? <br>
+
+1. how long it take you? <br>
+
+1. did you need to install additional packages or libraries? <br>
+
+1. were you able to build the code following the instructions? <br>
+
+1. did you need to look for additional help in installing the environment? <br>
+
+1. any other comments? <br>
+
+
+
+
+## Summary
+1. Do you think  this is a project to which it would be possible to contribute
+in the course of a few weeks before the end of this semester? <br>
+	<!--
+	Explain your position. Do NOT simply say 'yes or 'no'.
+	-->
+
+1. Would you be interested in contributing to this particular project? <br>
+	<!--
+	Explain why you would or would not be interested in contributing to this project. Do NOT simply say 'yes or 'no'.
+	-->

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -26,7 +26,7 @@ does it have?
 
 ## License
 
-1. What is the project's license? <br>
+1. What is the project's license? __BSD 3-Clause License__<br>
 <!--
 In most repositories there will be a file named LICENSE or something similar in
 the root level of the repository. This is the one to examine. There may be
@@ -41,6 +41,12 @@ different licenses on specific files, but the project will have a main license.
 1. What is the primary programming language in the project? __JavaScript__ <br>
 
 1. What is the development environment? <br>
+
+There are [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
+ to set up freeCodeCamp locally on your own system. They say to fork and clone the respository onto
+ your local machine and to simply install Git and your preferred code editor with ESLint setup.
+Or to develop on Gitpod, a free online development environment.
+<br>
 	<!--
 	For example, is it Gnu C++ on Linux?
 	Is it a Windows 10 application? Does one need to develop in a virtual machine?
@@ -49,8 +55,20 @@ different licenses on specific files, but the project will have a main license.
 1. Are there instructions for how to download, build, and install? How easy is it
 to find them? Do they seem easy (relatively speaking) to follow? <br>
 
+Yes, [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
+are here. Very easy to find them, as it is one of the first links on the CONTRIBUTING.md page. Instructions seem 
+pretty straightforward, and clean formatting helps.
+<br>
+
 1. Does the project depend on external additional software modules such as
 database,  graphics, web development, or other libraries? If so, are there clear instructions on how to install those? <br>
+
+You can choose to run a Docker build (recommended) or a Local build to run freeCodeCamp locally. For both the
+Docker build and the Local build, the project needs Node.js installed. For Docker build, you need Docker software 
+as specified in instructions, and for the Local build the project needs MongoDB Community Server installed. 
+There aren't instructions on how to install these modules, though links to them are included, but there are 
+instructions on how to run these modules to properly setup the enviornment.
+<br>
 
 1. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample. <br>

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -75,7 +75,7 @@ instructions on how to run these modules to properly setup the enviornment.
 1. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample. <br>
 
-Well, I have little to no experiene in JavaScript so I can't say for sure, but at the very least the source code seems to have 
+Well, I have little to no experience in JavaScript so I can't say for sure, but at the very least the source code seems to have 
 clearly named variables and has good readability. There are no comments though. I only sort o 
 understand what the code file I'm looking at is doing, but that's largely my inexperience with 
 JavaScript. If someone who was familiar with JS looked at this, I have a feeling they'd probably 
@@ -108,8 +108,8 @@ No.
 
 1. Is there documentation about the design?  <br>
  There is design docs for how to contribute to the coding challenges codebase: a Challenge Template 
-exists in the ["How to work on coding challengs" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
-but there doesn't seem to be any docs on coding style.
+exists in the ["How to work on coding challengs" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
+and there is also a JavaScript style guide linked to in the ["Set up freeCodeCamp locally" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md). 
 <br>
 
 ## Activity Level
@@ -153,9 +153,7 @@ month, which according to the stats is 54 closed issues from Feb 4th - Mar 4th. 
 <br>
 
 1. Is there information about how many people are maintaining the project? <br>
-They have a platform dev team listed in the Contribution guidelines that includes 3 people, and 
-they have various emails @freecodecamp.org they list if you have questions. But there doesn't seem 
-to be more than that about # of people maintaining the project.
+On the website About page, there's a picture of the freeCodeCamp Team with a caption that lists 7 names.
 <br>
 
 1. How many contributors has the project had in the past six months? <br>
@@ -196,31 +194,40 @@ Yes, quite clear and thorough.
 1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
 violate it? <br>
 
+CODE OF CONDUCT document links to the code of conducts page on [freeCodeCamp.org](https://www.freecodecamp.org/news/code-of-conduct/). 
+There are consequences for acts that violate it.
+<br>
+
 
 1. Do the maintainers respond helpfully to questions in issues?
 Are responses generally constructive? Read the issue conversations. <br>
+Yes, and yes.
+<br>
 
 1. Are people friendly in the issues, discussion forum, and chat? <br>
+Yes
+<br>
 
 1. Do maintainers thank people for their contributions? <br>
-
+Yes
+<br>
 
 ## Development Environment Installation
 
 Install the development environment for the project on your system.
 Describe the process that you needed to follow:
 
-1. how involved was the process? <br>
+1. how involved was the process? Very involved. <br>
 
-1. how long it take you? <br>
+1. how long it take you? Around half an hour. <br>
 
-1. did you need to install additional packages or libraries? <br>
+1. did you need to install additional packages or libraries? Yes. Node.js and Docker.<br>
 
-1. were you able to build the code following the instructions? <br>
+1. were you able to build the code following the instructions? Yes. <br>
 
-1. did you need to look for additional help in installing the environment? <br>
+1. did you need to look for additional help in installing the environment? No. <br>
 
-1. any other comments? <br>
+1. any other comments? n/a <br>
 
 
 
@@ -231,8 +238,16 @@ in the course of a few weeks before the end of this semester? <br>
 	<!--
 	Explain your position. Do NOT simply say 'yes or 'no'.
 	-->
+There are many ways to contribute outside of just coding in JavaScript, so yes, I think I 
+would be able to contribute in the timeframe.
+<br>
 
 1. Would you be interested in contributing to this particular project? <br>
 	<!--
 	Explain why you would or would not be interested in contributing to this project. Do NOT simply say 'yes or 'no'.
 	-->
+Possibly. I have been thinking about learning full-stack web development from freeCodeCamp's curriculum myself 
+(I've already started the HTML portion), so this project does interest me a lot as I think it is a very meaningful project. 
+Also, since the project is run on JavaScript and other web dev tools such as HTML, CSS, Node, it would be a good opportunity to 
+learn those more while I try contributing.
+<br>

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -73,11 +73,27 @@ instructions on how to run these modules to properly setup the enviornment.
 1. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample. <br>
 
+Well, I have little to no experiene in JavaScript so I can't say for sure, but at the very least the source code seems to have 
+clearly named variables and has good readability. There are no comments though. I only sort o 
+understand what the code file I'm looking at is doing, but that's largely my inexperience with 
+JavaScript. If someone who was familiar with JS looked at this, I have a feeling they'd probably 
+get the gist of it pretty easily.
+<br>
+
 1. Is this a big project? If you can, find out about how many lines of code
 are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 
+The project has around 36,000 lines of code (as of 3 months ago according to OpenHub). There are 
+currently 4005 contributors (as of 3/4/2020).
+<br>
+
 1. Does the repository have tests? If so, are the code contributors expected to write tests for newly added code? <br>
 
+FreeCodeCamp require you to indicate if you have tested a modification before making a pull 
+request, saying this is very important for non-documentation related changes. On their 
+[How to work on coding challengs page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) 
+they have detailed instructions on how to test code/function related changes.
+<br>
 
 
 ## Code and Design Documentation

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -12,15 +12,15 @@
 1. Project description: FreeCodeCamp.org is a website housing a community dedicated to 
 helping people learn to code for free. It has a free full-stack web dev curriculum, that 
 offers certification upon completion, with many interactive challenges and lessons. Its 
-intended audience seems to be adults. <br>
+intended audience seems to be adults.
 <!--
 What is the purpose of this project? What does the code do? What type of users
 does it have?
 -->
 
-1. Project website/homepage: [https://www.freecodecamp.org/](https://www.freecodecamp.org/)
+2. Project website/homepage: [https://www.freecodecamp.org/](https://www.freecodecamp.org/)
 
-1. Project repository: [https://github.com/freeCodeCamp/freeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp)
+3. Project repository: [https://github.com/freeCodeCamp/freeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp)
 
 
 
@@ -40,14 +40,17 @@ different licenses on specific files, but the project will have a main license.
 ## Code Base
 
 
-1. What is the primary programming language in the project? __JavaScript__ <br>
+1. What is the primary programming language in the project? <br>
+
+	__JavaScript__ 
+<br>
 
 1. What is the development environment? <br>
 
-There are [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
- to set up freeCodeCamp locally on your own system. They say to fork and clone the respository onto
- your local machine and to simply install Git and your preferred code editor with ESLint setup.
-Or to develop on Gitpod, a free online development environment.
+	There are [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
+ 	to set up freeCodeCamp locally on your own system. They say to fork and clone the respository onto
+ 	your local machine and to simply install Git and your preferred code editor with ESLint setup.
+	Or to develop on Gitpod, a free online development environment.
 <br>
 	<!--
 	For example, is it Gnu C++ on Linux?
@@ -57,59 +60,58 @@ Or to develop on Gitpod, a free online development environment.
 1. Are there instructions for how to download, build, and install? How easy is it
 to find them? Do they seem easy (relatively speaking) to follow? <br>
 
-Yes, [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
-are here. Very easy to find them, as it is one of the first links on the CONTRIBUTING.md page. Instructions seem 
-pretty straightforward, and clean formatting helps.
+	Yes, [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
+	are here. Very easy to find them, as it is one of the first links on the CONTRIBUTING.md page. Instructions seem 
+	pretty straightforward, and clean formatting helps.
 <br>
 
 1. Does the project depend on external additional software modules such as
 database,  graphics, web development, or other libraries? If so, are there clear instructions on how to install those? <br>
 
-You can choose to run a Docker build (recommended) or a Local build to run freeCodeCamp locally. For both the
-Docker build and the Local build, the project needs Node.js installed. For Docker build, you need Docker software 
-as specified in instructions, and for the Local build the project needs MongoDB Community Server installed. 
-There aren't instructions on how to install these modules, though links to them are included, but there are 
-instructions on how to run these modules to properly setup the enviornment.
+	You can choose to run a Docker build (recommended) or a Local build to run freeCodeCamp locally. For both the
+	Docker build and the Local build, the project needs Node.js installed. For Docker build, you need Docker software 
+	as specified in instructions, and for the Local build the project needs MongoDB Community Server installed. 
+	There aren't instructions on how to install these modules, though links to them are included, but there are 
+	instructions on how to run these modules to properly setup the enviornment.
 <br>
 
 1. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample. <br>
 
-Well, I have little to no experience in JavaScript so I can't say for sure, but at the very least the source code seems to have 
-clearly named variables and has good readability. There are no comments though. I only sort o 
-understand what the code file I'm looking at is doing, but that's largely my inexperience with 
-JavaScript. If someone who was familiar with JS looked at this, I have a feeling they'd probably 
-get the gist of it pretty easily.
+	Well, I have little to no experience in JavaScript so I can't say for sure, but at the very least the source code seems to have 
+	clearly named variables and has good readability. There are no comments though. I only sort of understand what the code file I'm looking at is doing, but that's largely my inexperience with JavaScript. If someone who was familiar with JS looked at this, I have a feeling they'd probably get the gist of it pretty easily.
 <br>
 
 1. Is this a big project? If you can, find out about how many lines of code
 are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 
-The project has around 36,000 lines of code (as of 3 months ago according to OpenHub). There are 
-currently 4005 contributors (as of 3/4/2020).
+	The project has around 36,000 lines of code (as of 3 months ago according to OpenHub). There are 
+	currently 4005 contributors (as of 3/4/2020).
 <br>
 
 1. Does the repository have tests? If so, are the code contributors expected to write tests for newly added code? <br>
 
-FreeCodeCamp require you to indicate if you have tested a modification before making a pull 
-request, saying this is very important for non-documentation related changes. On their 
-["How to work on coding challengs" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) 
-they have detailed instructions on how to test code/function related changes. 
+	FreeCodeCamp require you to indicate if you have tested a modification before making a pull 
+	request, saying this is very important for non-documentation related changes. On their 
+	["How to work on coding challengs" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) 
+	they have detailed instructions on how to test code/function related changes. 
 
-There is also a ["DevOps at freeCodeCamp" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/devops.md) that 
-talks about and has instructions on building/testing/deploying the codebase.
+	There is also a ["DevOps at freeCodeCamp" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/devops.md) that 
+	talks about and has instructions on building/testing/deploying the codebase.
 <br>
 
 
 ## Code and Design Documentation
 1. Is there clear documentation in the code itself? <br>
-No.
+
+	No.
 <br>
 
 1. Is there documentation about the design?  <br>
- There is design docs for how to contribute to the coding challenges codebase: a Challenge Template 
-exists in the ["How to work on coding challengs" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
-and there is also a JavaScript style guide linked to in the ["Set up freeCodeCamp locally" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md). 
+
+ 	There is design docs for how to contribute to the coding challenges codebase: a Challenge Template 
+	exists in the ["How to work on coding challengs" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
+	and there is also a JavaScript style guide linked to in the ["Set up freeCodeCamp locally" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md). 
 <br>
 
 ## Activity Level
@@ -117,21 +119,23 @@ and there is also a JavaScript style guide linked to in the ["Set up freeCodeCam
 
 1. How many commits have been made in the past week? <br>
 
-19 commits was made the week of Sunday Feb 23rd - Saturday Feb 29th, and 5 commits have been made 
-the week of Mar 1st so far (as of 1:04pm Mar 4th).
+	19 commits was made the week of Sunday Feb 23rd - Saturday Feb 29th, and 5 commits have been made 
+	the week of Mar 1st so far (as of 1:04pm Mar 4th).
 <br>
 
 1. When was the most recent commit? <br>
 
-Most recent commit was Tuesday Mar 3rd.
+	Most recent commit was Tuesday Mar 3rd.
 <br>
 
 1. How many issues are currently open? <br>
-166 open issues.
+
+	166 open issues.
 <br>
 
 1. How long do issues stay open? <br>
-An average of 1.8 days.
+
+	An average of 1.8 days.
 <br>
 	<!--
 	Take the five closed issues (they can be most recently closed or a sample distributed over time) and look at when each was first reported.
@@ -139,32 +143,41 @@ An average of 1.8 days.
 	-->
 
 1. Read the conversations from some open and some closed issues. Is there active discussion on the issues? <br>
-Yes there is. There seems to be same day responses for a lot of them, and are usually promptly resolved or has active discussion 
-for issues that take a bit longer to resolve.
+
+	Yes there is. There seems to be same day responses for a lot of them, and are usually promptly resolved or has active discussion 
+	for issues that take a bit longer to resolve.
 <br>
 
 1. Are issues tagged as easy, hard, for beginners, etc.? <br>
-There is a "first timers welcome" tag.
+
+	There is a "first timers welcome" tag.
 <br>
 
 1. How many issues were closed in the past six months? <br>
-There is no easy way to find this information. GitHub's analytics only seems to track up to the past 
-month, which according to the stats is 54 closed issues from Feb 4th - Mar 4th. (I'm not hand counting the issue tracker.)
+
+	There is no easy way to find this information. GitHub's analytics only seems to track up to the past 
+	month, which according to the stats is 54 closed issues from Feb 4th - Mar 4th. (I'm not hand counting the issue tracker.)
 <br>
 
 1. Is there information about how many people are maintaining the project? <br>
-On the website About page, there's a picture of the freeCodeCamp Team with a caption that lists 7 names.
+
+	On the website About page, there's a picture of the freeCodeCamp Team with a caption that lists 7 names.
 <br>
 
 1. How many contributors has the project had in the past six months? <br>
-Can't find it. The insights tab's Contributors section lists 20 contributors to master for the past 6 months. 
-However, the Pulse section under insights says 54 authors over the past month to master and many branches.
+
+	Can't find it. The insights tab's Contributors section lists 20 contributors to master for the past 6 months. 
+	However, the Pulse section under insights says 54 authors over the past month to master and many branches.
 <br>
+
 1. How many open pull requests are there? <br>
-84
+
+	84
 <br>
 1. Do pull requests remain un-answered for a long time? <br>
-Usually same day or within one day.
+
+	Usually same day or within one day.
+<br>
 	<!--
 	Look at the closed pull requests to see how long they stayed open.
 	Take the five closed pull requests  (they can be most recently closed or a sample distributed over time) and look at when each was first created.
@@ -172,44 +185,50 @@ Usually same day or within one day.
 	-->
 
 1. Read the conversations from some open and some closed pull requests.  Is there active discussion on the pull requests? <br>
-On pull requests that took longer than same day to close, there is active discussion and feedback on the pull request on how to improve 
-the pull requests. Otherwise, there is a Gitpod tester bot that tests the pull request and if it works they often get approved, if not then not approved. 
+
+	On pull requests that took longer than same day to close, there is active discussion and feedback on the pull request on how to improve 
+	the pull requests. Otherwise, there is a Gitpod tester bot that tests the pull request and if it works they often get approved, if not then not approved. 
 <br>
 
 1. How many pull requests were opened within the past six months? <br>
-GitHub stats only shows up to past month. If I were to estimate based off going through the pages in the Pull Requests tab, over 1000 have been opened since September 3rd.
+
+	GitHub stats only shows up to past month. If I were to estimate based off going through the pages in the Pull Requests tab, over 1000 have been opened since September 3rd.
 <br>
 
 1. When was the last  pull request  merged? <br>
-Yesterday.
+
+	Yesterday.
 <br>
 ## Welcomeness and Community
 
 1. Is there a CONTRIBUTING document? If so, how easy to read and understand is it?
 Look through it and see if it is clear and thorough. <br>
 
-Yes, quite clear and thorough.
+	Yes, quite clear and thorough.
 <br>
 
 1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
 violate it? <br>
 
-CODE OF CONDUCT document links to the code of conducts page on [freeCodeCamp.org](https://www.freecodecamp.org/news/code-of-conduct/). 
-There are consequences for acts that violate it.
+	CODE OF CONDUCT document links to the code of conducts page on [freeCodeCamp.org](https://www.freecodecamp.org/news/code-of-conduct/). 
+	There are consequences for acts that violate it.
 <br>
 
 
 1. Do the maintainers respond helpfully to questions in issues?
 Are responses generally constructive? Read the issue conversations. <br>
-Yes, and yes.
+
+	Yes, and yes.
 <br>
 
 1. Are people friendly in the issues, discussion forum, and chat? <br>
-Yes
+
+	Yes
 <br>
 
 1. Do maintainers thank people for their contributions? <br>
-Yes
+
+	Yes
 <br>
 
 ## Development Environment Installation
@@ -217,17 +236,35 @@ Yes
 Install the development environment for the project on your system.
 Describe the process that you needed to follow:
 
-1. how involved was the process? Very involved. <br>
+1. how involved was the process?  <br>
 
-1. how long it take you? Around half an hour. <br>
+	Very involved. 
+<br>
 
-1. did you need to install additional packages or libraries? Yes. Node.js and Docker.<br>
+1. how long it take you? <br>
+	
+	Around half an hour. 
+<br>
 
-1. were you able to build the code following the instructions? Yes. <br>
+1. did you need to install additional packages or libraries? <br>
 
-1. did you need to look for additional help in installing the environment? No. <br>
+	Yes. Node.js and Docker.
+<br>
 
-1. any other comments? n/a <br>
+1. were you able to build the code following the instructions? <br>
+
+	Yes. 
+<br>
+
+1. did you need to look for additional help in installing the environment? <br>
+	
+	No. 
+<br>
+
+1. any other comments? <br>
+
+	n/a 
+<br>
 
 
 
@@ -238,16 +275,17 @@ in the course of a few weeks before the end of this semester? <br>
 	<!--
 	Explain your position. Do NOT simply say 'yes or 'no'.
 	-->
-There are many ways to contribute outside of just coding in JavaScript, so yes, I think I 
-would be able to contribute in the timeframe.
+
+	There are many ways to contribute outside of just coding in JavaScript, so yes, I think I would be able to contribute in the timeframe.
 <br>
 
 1. Would you be interested in contributing to this particular project? <br>
 	<!--
 	Explain why you would or would not be interested in contributing to this project. Do NOT simply say 'yes or 'no'.
 	-->
-Possibly. I have been thinking about learning full-stack web development from freeCodeCamp's curriculum myself 
-(I've already started the HTML portion), so this project does interest me a lot as I think it is a very meaningful project. 
-Also, since the project is run on JavaScript and other web dev tools such as HTML, CSS, Node, it would be a good opportunity to 
-learn those more while I try contributing.
+
+	Possibly. I have been thinking about learning full-stack web development from freeCodeCamp's curriculum myself 
+	(I've already started the HTML portion), so this project does interest me a lot as I think it is a very meaningful project. 
+	Also, since the project is run on JavaScript and other web dev tools such as HTML, CSS, Node, it would be a good opportunity to 
+	learn those more while I try contributing.
 <br>

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -26,7 +26,9 @@ does it have?
 
 ## License
 
-1. What is the project's license? __BSD 3-Clause License__<br>
+1. What is the project's license? <br>
+The main license is __BSD 3-Clause__ license whereas the learning resources in the /curriculum
+directory is under the __CC-BY-SA-4.0__ license.
 <!--
 In most repositories there will be a file named LICENSE or something similar in
 the root level of the repository. This is the one to examine. There may be
@@ -91,45 +93,80 @@ currently 4005 contributors (as of 3/4/2020).
 
 FreeCodeCamp require you to indicate if you have tested a modification before making a pull 
 request, saying this is very important for non-documentation related changes. On their 
-[How to work on coding challengs page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) 
-they have detailed instructions on how to test code/function related changes.
+["How to work on coding challengs" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) 
+they have detailed instructions on how to test code/function related changes. 
+
+There is also a ["DevOps at freeCodeCamp" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/devops.md) that 
+talks about and has instructions on building/testing/deploying the codebase.
 <br>
 
 
 ## Code and Design Documentation
 1. Is there clear documentation in the code itself? <br>
+No.
+<br>
 
 1. Is there documentation about the design?  <br>
-
+ There is design docs for how to contribute to the coding challenges codebase: a Challenge Template 
+exists in the ["How to work on coding challengs" page](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
+but there doesn't seem to be any docs on coding style.
+<br>
 
 ## Activity Level
 
 
 1. How many commits have been made in the past week? <br>
 
+19 commits was made the week of Sunday Feb 23rd - Saturday Feb 29th, and 5 commits have been made 
+the week of Mar 1st so far (as of 1:04pm Mar 4th).
+<br>
+
 1. When was the most recent commit? <br>
 
+Most recent commit was Tuesday Mar 3rd.
+<br>
+
 1. How many issues are currently open? <br>
+166 open issues.
+<br>
 
 1. How long do issues stay open? <br>
+An average of 1.8 days.
+<br>
 	<!--
 	Take the five closed issues (they can be most recently closed or a sample distributed over time) and look at when each was first reported.
 	Compute the number of days that each was open and take the average.
 	-->
 
 1. Read the conversations from some open and some closed issues. Is there active discussion on the issues? <br>
+Yes there is. There seems to be same day responses for a lot of them, and are usually promptly resolved or has active discussion 
+for issues that take a bit longer to resolve.
+<br>
 
 1. Are issues tagged as easy, hard, for beginners, etc.? <br>
+There is a "first timers welcome" tag.
+<br>
 
 1. How many issues were closed in the past six months? <br>
+There is no easy way to find this information. GitHub's analytics only seems to track up to the past 
+month, which according to the stats is 54 closed issues from Feb 4th - Mar 4th. (I'm not hand counting the issue tracker.)
+<br>
 
 1. Is there information about how many people are maintaining the project? <br>
+They have a platform dev team listed in the Contribution guidelines that includes 3 people, and 
+they have various emails @freecodecamp.org they list if you have questions. But there doesn't seem 
+to be more than that about # of people maintaining the project.
+<br>
 
 1. How many contributors has the project had in the past six months? <br>
-
+Can't find it. The insights tab's Contributors section lists 20 contributors to master for the past 6 months. 
+However, the Pulse section under insights says 54 authors over the past month to master and many branches.
+<br>
 1. How many open pull requests are there? <br>
-
+84
+<br>
 1. Do pull requests remain un-answered for a long time? <br>
+Usually same day or within one day.
 	<!--
 	Look at the closed pull requests to see how long they stayed open.
 	Take the five closed pull requests  (they can be most recently closed or a sample distributed over time) and look at when each was first created.
@@ -137,18 +174,28 @@ they have detailed instructions on how to test code/function related changes.
 	-->
 
 1. Read the conversations from some open and some closed pull requests.  Is there active discussion on the pull requests? <br>
+On pull requests that took longer than same day to close, there is active discussion and feedback on the pull request on how to improve 
+the pull requests. Otherwise, there is a Gitpod tester bot that tests the pull request and if it works they often get approved, if not then not approved. 
+<br>
 
 1. How many pull requests were opened within the past six months? <br>
+GitHub stats only shows up to past month. If I were to estimate based off going through the pages in the Pull Requests tab, over 1000 have been opened since September 3rd.
+<br>
 
 1. When was the last  pull request  merged? <br>
-
+Yesterday.
+<br>
 ## Welcomeness and Community
 
 1. Is there a CONTRIBUTING document? If so, how easy to read and understand is it?
 Look through it and see if it is clear and thorough. <br>
 
+Yes, quite clear and thorough.
+<br>
+
 1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
 violate it? <br>
+
 
 1. Do the maintainers respond helpfully to questions in issues?
 Are responses generally constructive? Read the issue conversations. <br>

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -45,7 +45,7 @@ different licenses on specific files, but the project will have a main license.
 	__JavaScript__ 
 <br>
 
-1. What is the development environment? <br>
+2. What is the development environment? <br>
 
 	There are [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
  	to set up freeCodeCamp locally on your own system. They say to fork and clone the respository onto
@@ -57,7 +57,7 @@ different licenses on specific files, but the project will have a main license.
 	Is it a Windows 10 application? Does one need to develop in a virtual machine?
 	-->
 
-1. Are there instructions for how to download, build, and install? How easy is it
+3. Are there instructions for how to download, build, and install? How easy is it
 to find them? Do they seem easy (relatively speaking) to follow? <br>
 
 	Yes, [instructions](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-setup-freecodecamp-locally.md)
@@ -65,7 +65,7 @@ to find them? Do they seem easy (relatively speaking) to follow? <br>
 	pretty straightforward, and clean formatting helps.
 <br>
 
-1. Does the project depend on external additional software modules such as
+4. Does the project depend on external additional software modules such as
 database,  graphics, web development, or other libraries? If so, are there clear instructions on how to install those? <br>
 
 	You can choose to run a Docker build (recommended) or a Local build to run freeCodeCamp locally. For both the
@@ -75,21 +75,21 @@ database,  graphics, web development, or other libraries? If so, are there clear
 	instructions on how to run these modules to properly setup the enviornment.
 <br>
 
-1. Is the code easy to understand? Browse some source code files and make
+5. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample. <br>
 
 	Well, I have little to no experience in JavaScript so I can't say for sure, but at the very least the source code seems to have 
 	clearly named variables and has good readability. There are no comments though. I only sort of understand what the code file I'm looking at is doing, but that's largely my inexperience with JavaScript. If someone who was familiar with JS looked at this, I have a feeling they'd probably get the gist of it pretty easily.
 <br>
 
-1. Is this a big project? If you can, find out about how many lines of code
+6. Is this a big project? If you can, find out about how many lines of code
 are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 
 	The project has around 36,000 lines of code (as of 3 months ago according to OpenHub). There are 
 	currently 4005 contributors (as of 3/4/2020).
 <br>
 
-1. Does the repository have tests? If so, are the code contributors expected to write tests for newly added code? <br>
+7. Does the repository have tests? If so, are the code contributors expected to write tests for newly added code? <br>
 
 	FreeCodeCamp require you to indicate if you have tested a modification before making a pull 
 	request, saying this is very important for non-documentation related changes. On their 
@@ -107,7 +107,7 @@ are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 	No.
 <br>
 
-1. Is there documentation about the design?  <br>
+2. Is there documentation about the design?  <br>
 
  	There is design docs for how to contribute to the coding challenges codebase: a Challenge Template 
 	exists in the ["How to work on coding challengs" doc](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md). 
@@ -123,17 +123,17 @@ are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 	the week of Mar 1st so far (as of 1:04pm Mar 4th).
 <br>
 
-1. When was the most recent commit? <br>
+2. When was the most recent commit? <br>
 
 	Most recent commit was Tuesday Mar 3rd.
 <br>
 
-1. How many issues are currently open? <br>
+3. How many issues are currently open? <br>
 
 	166 open issues.
 <br>
 
-1. How long do issues stay open? <br>
+4. How long do issues stay open? <br>
 
 	An average of 1.8 days.
 <br>
@@ -142,39 +142,40 @@ are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 	Compute the number of days that each was open and take the average.
 	-->
 
-1. Read the conversations from some open and some closed issues. Is there active discussion on the issues? <br>
+5. Read the conversations from some open and some closed issues. Is there active discussion on the issues? <br>
 
 	Yes there is. There seems to be same day responses for a lot of them, and are usually promptly resolved or has active discussion 
 	for issues that take a bit longer to resolve.
 <br>
 
-1. Are issues tagged as easy, hard, for beginners, etc.? <br>
+6. Are issues tagged as easy, hard, for beginners, etc.? <br>
 
 	There is a "first timers welcome" tag.
 <br>
 
-1. How many issues were closed in the past six months? <br>
+7. How many issues were closed in the past six months? <br>
 
 	There is no easy way to find this information. GitHub's analytics only seems to track up to the past 
 	month, which according to the stats is 54 closed issues from Feb 4th - Mar 4th. (I'm not hand counting the issue tracker.)
 <br>
 
-1. Is there information about how many people are maintaining the project? <br>
+8. Is there information about how many people are maintaining the project? <br>
 
 	On the website About page, there's a picture of the freeCodeCamp Team with a caption that lists 7 names.
 <br>
 
-1. How many contributors has the project had in the past six months? <br>
+9. How many contributors has the project had in the past six months? <br>
 
 	Can't find it. The insights tab's Contributors section lists 20 contributors to master for the past 6 months. 
 	However, the Pulse section under insights says 54 authors over the past month to master and many branches.
 <br>
 
-1. How many open pull requests are there? <br>
+10. How many open pull requests are there? <br>
 
 	84
 <br>
-1. Do pull requests remain un-answered for a long time? <br>
+
+11. Do pull requests remain un-answered for a long time? <br>
 
 	Usually same day or within one day.
 <br>
@@ -184,21 +185,22 @@ are in it, perhaps on [OpenHub](https://www.openhub.net/). <br>
 	Compute the number of days that each was open and take the average.
 	-->
 
-1. Read the conversations from some open and some closed pull requests.  Is there active discussion on the pull requests? <br>
+12. Read the conversations from some open and some closed pull requests.  Is there active discussion on the pull requests? <br>
 
 	On pull requests that took longer than same day to close, there is active discussion and feedback on the pull request on how to improve 
 	the pull requests. Otherwise, there is a Gitpod tester bot that tests the pull request and if it works they often get approved, if not then not approved. 
 <br>
 
-1. How many pull requests were opened within the past six months? <br>
+13. How many pull requests were opened within the past six months? <br>
 
 	GitHub stats only shows up to past month. If I were to estimate based off going through the pages in the Pull Requests tab, over 1000 have been opened since September 3rd.
 <br>
 
-1. When was the last  pull request  merged? <br>
+14. When was the last  pull request  merged? <br>
 
 	Yesterday.
 <br>
+
 ## Welcomeness and Community
 
 1. Is there a CONTRIBUTING document? If so, how easy to read and understand is it?
@@ -207,7 +209,7 @@ Look through it and see if it is clear and thorough. <br>
 	Yes, quite clear and thorough.
 <br>
 
-1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
+2. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
 violate it? <br>
 
 	CODE OF CONDUCT document links to the code of conducts page on [freeCodeCamp.org](https://www.freecodecamp.org/news/code-of-conduct/). 
@@ -215,18 +217,18 @@ violate it? <br>
 <br>
 
 
-1. Do the maintainers respond helpfully to questions in issues?
+3. Do the maintainers respond helpfully to questions in issues?
 Are responses generally constructive? Read the issue conversations. <br>
 
 	Yes, and yes.
 <br>
 
-1. Are people friendly in the issues, discussion forum, and chat? <br>
+4. Are people friendly in the issues, discussion forum, and chat? <br>
 
 	Yes
 <br>
 
-1. Do maintainers thank people for their contributions? <br>
+5. Do maintainers thank people for their contributions? <br>
 
 	Yes
 <br>
@@ -241,27 +243,27 @@ Describe the process that you needed to follow:
 	Very involved. 
 <br>
 
-1. how long it take you? <br>
+2. how long it take you? <br>
 	
 	Around half an hour. 
 <br>
 
-1. did you need to install additional packages or libraries? <br>
+3. did you need to install additional packages or libraries? <br>
 
 	Yes. Node.js and Docker.
 <br>
 
-1. were you able to build the code following the instructions? <br>
+4. were you able to build the code following the instructions? <br>
 
 	Yes. 
 <br>
 
-1. did you need to look for additional help in installing the environment? <br>
+5. did you need to look for additional help in installing the environment? <br>
 	
 	No. 
 <br>
 
-1. any other comments? <br>
+6. any other comments? <br>
 
 	n/a 
 <br>
@@ -279,7 +281,7 @@ in the course of a few weeks before the end of this semester? <br>
 	There are many ways to contribute outside of just coding in JavaScript, so yes, I think I would be able to contribute in the timeframe.
 <br>
 
-1. Would you be interested in contributing to this particular project? <br>
+2. Would you be interested in contributing to this particular project? <br>
 	<!--
 	Explain why you would or would not be interested in contributing to this project. Do NOT simply say 'yes or 'no'.
 	-->

--- a/FreeCodeCamp_evaluation.md
+++ b/FreeCodeCamp_evaluation.md
@@ -1,23 +1,26 @@
-# Project Name:  <!-- replace with the project name -->   
+# Project Name: FreeCodeCamp <!-- replace with the project name -->   
 
 
 
-**Evaluating Person or Team**:
+**Evaluating Person or Team**: Austin, austintian03
 <!-- list your first name and github user-name-->
 
 ---
 
 ## Project Data
 
-1. Project description: <br>
+1. Project description: FreeCodeCamp.org is a website housing a community dedicated to 
+helping people learn to code for free. It has a free full-stack web dev curriculum, that 
+offers certification upon completion, with many interactive challenges and lessons. Its 
+intended audience seems to be adults. <br>
 <!--
 What is the purpose of this project? What does the code do? What type of users
 does it have?
 -->
 
-1. Project website/homepage:
+1. Project website/homepage: [https://www.freecodecamp.org/](https://www.freecodecamp.org/)
 
-1. Project repository:
+1. Project repository: [https://github.com/freeCodeCamp/freeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp)
 
 
 
@@ -35,7 +38,7 @@ different licenses on specific files, but the project will have a main license.
 ## Code Base
 
 
-1. What is the primary programming language in the project?
+1. What is the primary programming language in the project? __JavaScript__ <br>
 
 1. What is the development environment? <br>
 	<!--


### PR DESCRIPTION
How do we find stats about # of issues and pull requests that are opened/closed over set periods of time? I could not find hard numbers for the questions pertaining to # of issues and pull requests opened/closed in the past 6 months on GitHub. This project evaluation took me over 3 hours to complete somehow...